### PR TITLE
Use camptocamp/systemd for rc-local.service

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,7 @@
 fixtures:
   repositories:
     "stdlib": "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+    "systemd": "https://forge.puppet.com/camptocamp/systemd.git"
   symlinks:
     "rclocal": "#{source_dir}"
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This module manages rc.local entries in /etc/rc.local file directory.
 
 This module uses Data Types from puppetlabs-stdlib!
 
+Systemd based systems will need [camptocamp/systemd](https://forge.puppet.com/camptocamp/systemd).
+
 ## Usage
 
 To only manage the content of rc.local file:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,14 +56,15 @@ class rclocal(
 
   if $facts['service_provider'] == 'systemd' {
     ### Systemd support
-    file { '/etc/systemd/system/rc-local.service':
-      ensure  => file,
-      mode    => '0644',
+    systemd::unit_file { 'rc-local.service':
+      ensure  => 'present',
       content => epp('rclocal/systemd_rc-local.service.epp'),
+      notify  => Service['rc-local'],
     }
     service { 'rc-local':
-      ensure => running,
-      enable => true,
+      ensure  => running,
+      enable  => true,
+      require => Class['systemd::systemctl::daemon_reload'],
     }
   }
 


### PR DESCRIPTION
This fixes #19 and does so by relying on `systemd/camptocamp` for the systemd unit file management. I added to README as soft dependency since only applies to systemd systems.